### PR TITLE
First price deletion

### DIFF
--- a/src/Pool.sol
+++ b/src/Pool.sol
@@ -139,6 +139,7 @@ contract Pool is IPool {
             // we approximate it with the nearest one, with priority upwards
             if (
                 (!_checkMidSpacing(_nextPriceLevels[higherPrice], price) || !_checkMidSpacing(price, higherPrice)) &&
+                _nextPriceLevels[higherPrice] != 0 &&
                 higherPrice != 0
             ) {
                 price = price - _nextPriceLevels[higherPrice] < higherPrice - price
@@ -147,6 +148,8 @@ contract Pool is IPool {
                 updatePrices = false;
             }
 
+            // In case updatePrices = false we have fallen into already existing price levels
+            // therefore we only need to update prices if the flag is true
             if (updatePrices) {
                 _nextPriceLevels[price] = _nextPriceLevels[higherPrice];
                 _nextPriceLevels[higherPrice] = price;
@@ -337,6 +340,7 @@ contract Pool is IPool {
             // we approximate it with the nearest one, with priority upwards
             if (
                 (!_checkMidSpacing(_nextPriceLevels[higherPrice], price) || !_checkMidSpacing(price, higherPrice)) &&
+                _nextPriceLevels[higherPrice] != 0 &&
                 higherPrice != 0
             ) {
                 actualPrice = price - _nextPriceLevels[higherPrice] < higherPrice - price

--- a/src/Pool.sol
+++ b/src/Pool.sol
@@ -123,6 +123,7 @@ contract Pool is IPool {
         }
 
         if (_nextPriceLevels[higherPrice] < price) {
+            bool updatePrices = true;
             // If price is the highest so far and too close to the previous highest
             // round it up to the smallest available tick
             if (!_checkExtSpacing(_nextPriceLevels[higherPrice], price) && higherPrice == 0) {
@@ -132,20 +133,24 @@ contract Pool is IPool {
             // round it up to the previous lowest
             if (!_checkExtSpacing(price, higherPrice) && _nextPriceLevels[higherPrice] == 0 && higherPrice != 0) {
                 price = higherPrice;
+                updatePrices = false;
             }
             // If price is in the middle of two price levels and does not respect tick spacing
             // we approximate it with the nearest one, with priority upwards
             if (
-                !_checkMidSpacing(_nextPriceLevels[higherPrice], price) ||
-                (!_checkMidSpacing(price, higherPrice) && higherPrice != 0)
+                (!_checkMidSpacing(_nextPriceLevels[higherPrice], price) || !_checkMidSpacing(price, higherPrice)) &&
+                higherPrice != 0
             ) {
                 price = price - _nextPriceLevels[higherPrice] < higherPrice - price
                     ? _nextPriceLevels[higherPrice]
                     : higherPrice;
+                updatePrices = false;
             }
 
-            _nextPriceLevels[price] = _nextPriceLevels[higherPrice];
-            _nextPriceLevels[higherPrice] = price;
+            if (updatePrices) {
+                _nextPriceLevels[price] = _nextPriceLevels[higherPrice];
+                _nextPriceLevels[higherPrice] = price;
+            }
         }
 
         // The "next" index of the last order is 0
@@ -319,19 +324,20 @@ contract Pool is IPool {
         if (_nextPriceLevels[higherPrice] < price) {
             // If price is the highest so far and too close to the previous highest
             // round it up to the smallest available tick
-            if (!_checkExtSpacing(_nextPriceLevels[higherPrice], price) && higherPrice == 0)
+            if (!_checkExtSpacing(_nextPriceLevels[higherPrice], price) && higherPrice == 0) {
                 actualPrice = _nextPriceLevels[higherPrice].mulDiv(tick + 10000, 10000, Math.Rounding.Up);
-
+            }
             // If price is the lowest so far and too close to the previous lowest
             // round it up to the previous lowest
-            if (!_checkExtSpacing(price, higherPrice) && _nextPriceLevels[higherPrice] == 0 && higherPrice != 0)
+            if (!_checkExtSpacing(price, higherPrice) && _nextPriceLevels[higherPrice] == 0 && higherPrice != 0) {
                 actualPrice = higherPrice;
+            }
 
             // If price is in the middle of two price levels and does not respect tick spacing
             // we approximate it with the nearest one, with priority upwards
             if (
-                !_checkMidSpacing(_nextPriceLevels[higherPrice], price) ||
-                (!_checkMidSpacing(price, higherPrice) && higherPrice != 0)
+                (!_checkMidSpacing(_nextPriceLevels[higherPrice], price) || !_checkMidSpacing(price, higherPrice)) &&
+                higherPrice != 0
             ) {
                 actualPrice = price - _nextPriceLevels[higherPrice] < higherPrice - price
                     ? _nextPriceLevels[higherPrice]

--- a/test/Pool.unit.test.sol
+++ b/test/Pool.unit.test.sol
@@ -323,6 +323,23 @@ contract PoolUnitTest is Test {
         assertEq(newVolumes[2].volume, oldVolumes[1].volume);
         assertEq(newVolumes[3].price, oldVolumes[2].price);
         assertEq(newVolumes[3].volume, oldVolumes[2].volume);
+        oldVolumes = newVolumes;
+
+        // price lower than all prices but not respecting tick spacing
+        amountMade = 0.7e6;
+        price = oldVolumes[3].price - 1;
+        (, , , , actualPrice) = swapper.previewOrder(price, 0);
+        assertEq(actualPrice, oldVolumes[3].price);
+        swapper.createOrder(amountMade, price, address(this), block.timestamp + 1000);
+        newVolumes = swapper.volumes(0, 0, 4);
+        assertEq(newVolumes[0].price, oldVolumes[0].price);
+        assertEq(newVolumes[0].volume, oldVolumes[0].volume);
+        assertEq(newVolumes[1].price, oldVolumes[1].price);
+        assertEq(newVolumes[1].volume, oldVolumes[1].volume);
+        assertEq(newVolumes[2].price, oldVolumes[2].price);
+        assertEq(newVolumes[2].volume, oldVolumes[2].volume);
+        assertEq(newVolumes[3].price, oldVolumes[3].price);
+        assertEq(newVolumes[3].volume, oldVolumes[3].volume + amountMade);
     }
 
     function testVolumesCancel() public {


### PR DESCRIPTION
The price level update showed a bug in case after rounding the price fell into an already existing price. This case occurred if the price was rounded in the middle of two existing prices or if the rounded price was the lowest so far. In the correct behavior, the price level should be updated in two cases only:
- when the rounded price is the highest price so far
- when there is no rounding.

A boolean flag is inserted to control this and further tests are implemented to cover rounding in all three cases (h > p > n(h), p > h, n(h) > p where h is the higher/highest price and n(h) is the one next to it in the nextPriceLevel ladder). Furthermore, with a small modification of the "if" conditions, the three rounding cases are set up to be mutually exclusive.